### PR TITLE
Update v0.rs

### DIFF
--- a/examples/v0.rs
+++ b/examples/v0.rs
@@ -85,7 +85,13 @@ fn main() -> anyhow::Result<()> {
     // data and would get them from there.
     psbt.inputs[0].witness_utxo = Some(alice.input_utxo());
     psbt.inputs[1].witness_utxo = Some(bob.input_utxo());
-
+    
+    // if psbt.bip32_derivation does not have public key : KeySource, the keypair never signs the transaction because
+    // psbt.sign calls bip32_sign_ecdsa() for ecdsa signatures, and bip32_sign_ecdsa() iterates over psbt.bip32_derivation
+    let fake_fp: [u8; 4] = [0; 4];
+    psbt.inputs[0].bip32_derivation.insert(alice.0.pk.clone(), (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
+    psbt.inputs[1].bip32_derivation.insert(bob.0.pk.clone(), (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
+    
     // Since we are spending 2 p2wpkh inputs there are no other updates needed.
 
     // Each party signs a copy of the PSBT.


### PR DESCRIPTION
Thank you, your repo is super helpful to me. I can't get v0.rs to sign the psbt as is. If psbt.bip32_derivation does not have public key : KeySource, the keypair never signs the transaction because psbt.sign calls bip32_sign_ecdsa() for ecdsa signatures, and bip32_sign_ecdsa() iterates over psbt.bip32_derivation, so I faked the BTreeMap<PublicKey, KeySource> entries for each pk. Thanks again! BE